### PR TITLE
Fix minor grammar error and a wordy phrase

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Two-dimensional code length, optional, default is 256 (PS: if magnification is n
 
 Magnification, optional, default is nil.
 
-Because in accordance with the existence of size scaling two-dimensional code clarity is not high, if you want to get a more clear two-dimensional code, you can use magnification to set the size of the final generation of two-dimensional code. Here is the smallest ratio relative to the two-dimensional code matrix is concerned, if there is a want size but I hope to have a clear and size and have size approximation of the two-dimensional code by using magnification, through `maxMagnificationLessThanOrEqualTo (size: CGFloat), and `minMagnificationGreaterThanOrEqualTo (size: CGFloat), want to get magnification these two functions the specific value, the use of specific methods are as follows:
+Because by the existence of size scaling two-dimensional code clarity is not high, if you want to get a more clear two-dimensional code, you can use magnification to set the size of the final generation of two-dimensional code. Here is the smallest ratio relative to the two-dimensional code matrix is concerned, if there is a wanted size but I hope to have a clear and size and have size approximation of the two-dimensional code by using magnification, through `maxMagnificationLessThanOrEqualTo (size: CGFloat), and `minMagnificationGreaterThanOrEqualTo (size: CGFloat), want to get magnification these two functions the specific value, the use of specific methods are as follows:
 
 ```
 let generator = EFQRCodeGenerator(


### PR DESCRIPTION
"if there is a want size" -> "if there is a wanted size"
"Because in accordance with the existence" -> "Because by the existence"
Fix #1 