### PR TITLE
Add WatermarkMode to Swift generate function

### DIFF
--- a/Source/EFQRCode.swift
+++ b/Source/EFQRCode.swift
@@ -40,14 +40,14 @@ public class EFQRCode: NSObject {
         backgroundColor: CIColor = CIColor.EFWhite(),
         foregroundColor: CIColor = CIColor.EFBlack(),
         watermark: CGImage? = nil,
-        watermarkMode: EFWatermarkMode? = .scaleAspectFit
+        watermarkMode mode: EFWatermarkMode? = .scaleAspectFit
         ) -> CGImage? {
 
         let generator = EFQRCodeGenerator(
             content: content,
             size: size
         )
-        generator.setWatermark(watermark: watermark, mode: watermarkMode)
+        generator.setWatermark(watermark: watermark, mode: mode)
         generator.setColors(backgroundColor: backgroundColor, foregroundColor: foregroundColor)
         return generator.generate()
     }

--- a/Source/EFQRCode.swift
+++ b/Source/EFQRCode.swift
@@ -39,14 +39,15 @@ public class EFQRCode: NSObject {
         size: EFIntSize = EFIntSize(width: 600, height: 600),
         backgroundColor: CIColor = CIColor.EFWhite(),
         foregroundColor: CIColor = CIColor.EFBlack(),
-        watermark: CGImage? = nil
+        watermark: CGImage? = nil,
+        watermarkMode: EFWatermarkMode? = .scaleAspectFit
         ) -> CGImage? {
 
         let generator = EFQRCodeGenerator(
             content: content,
             size: size
         )
-        generator.setWatermark(watermark: watermark)
+        generator.setWatermark(watermark: watermark, mode: watermarkMode)
         generator.setColors(backgroundColor: backgroundColor, foregroundColor: foregroundColor)
         return generator.generate()
     }


### PR DESCRIPTION
This small change gives the user the ability to better customize the watermark they put in their QR codes